### PR TITLE
Fix typo in user facing UI and code base

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -480,7 +480,7 @@ public class ApplicationContext extends MultiDexApplication implements AppForegr
 
     if (unifiedPushAvailable || forceWebSocket
         || fcmStatus == PlayServicesUtil.PlayServicesStatus.DISABLED) {
-      if (unifiedPushAvailable && !SignalStore.unifiedpush().getAirGaped()) {
+      if (unifiedPushAvailable && !SignalStore.unifiedpush().getAirGapped()) {
         ApplicationDependencies.getJobManager().add(new UnifiedPushRefreshJob());
       }
       ApplicationDependencies.getJobManager().cancel(new FcmRefreshJob().getId());

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/notifications/NotificationsSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/notifications/NotificationsSettingsViewModel.kt
@@ -128,7 +128,7 @@ class NotificationsSettingsViewModel(private val sharedPreferences: SharedPrefer
       } ?: return
     } else {
       UnifiedPush.unregisterApp(context)
-      SignalStore.unifiedpush().airGaped = false
+      SignalStore.unifiedpush().airGapped = false
       ApplicationDependencies.getJobManager().add(UnifiedPushRefreshJob())
     }
     refresh()

--- a/app/src/main/res/values/strings2.xml
+++ b/app/src/main/res/values/strings2.xml
@@ -117,7 +117,7 @@
     <string name="UnifiedPushSettingsFragment__method">Notification method</string>
     <string name="UnifiedPushSettingsFragment__status">Status</string>
     <string name="UnifiedPushSettingsFragment__click_to_copy">Click to copy</string>
-    <string name="UnifiedPushSettingsFragment__air_gaped">Air gaped</string>
+    <string name="UnifiedPushSettingsFragment__air_gaped">Air gapped</string>
     <string name="UnifiedPushSettingsFragment__server_parameters">Server parameters</string>
     <string name="UnifiedPushSettingsFragment__account_id">Account ID</string>
     <string name="UnifiedPushSettingsFragment__unknown">Unknown</string>
@@ -127,7 +127,7 @@
     <string name="UnifiedPushSettingsFragment__no_endpoint">No endpoint</string>
     <string name="UnifiedPushSettingsFragment__ok">Ok</string>
     <string name="UnifiedPushSettingsFragment__status_summary_disabled">Disabled</string>
-    <string name="UnifiedPushSettingsFragment__status_summary_air_gaped">Ok: Air Gaped</string>
+    <string name="UnifiedPushSettingsFragment__status_summary_air_gaped">Ok: Air Gapped</string>
     <string name="UnifiedPushSettingsFragment__status_summary_mollysocket_url_missing">MollySocket url missing</string>
     <string name="UnifiedPushSettingsFragment__status_summary_pending">Pending</string>
     <string name="UnifiedPushSettingsFragment__status_summary_mollysocket_server_not_found">MollySocket server not found</string>

--- a/app/src/main/res/values/strings2.xml
+++ b/app/src/main/res/values/strings2.xml
@@ -117,7 +117,7 @@
     <string name="UnifiedPushSettingsFragment__method">Notification method</string>
     <string name="UnifiedPushSettingsFragment__status">Status</string>
     <string name="UnifiedPushSettingsFragment__click_to_copy">Click to copy</string>
-    <string name="UnifiedPushSettingsFragment__air_gaped">Air gapped</string>
+    <string name="UnifiedPushSettingsFragment__air_gapped">Air gapped</string>
     <string name="UnifiedPushSettingsFragment__server_parameters">Server parameters</string>
     <string name="UnifiedPushSettingsFragment__account_id">Account ID</string>
     <string name="UnifiedPushSettingsFragment__unknown">Unknown</string>
@@ -127,7 +127,7 @@
     <string name="UnifiedPushSettingsFragment__no_endpoint">No endpoint</string>
     <string name="UnifiedPushSettingsFragment__ok">Ok</string>
     <string name="UnifiedPushSettingsFragment__status_summary_disabled">Disabled</string>
-    <string name="UnifiedPushSettingsFragment__status_summary_air_gaped">Ok: Air Gapped</string>
+    <string name="UnifiedPushSettingsFragment__status_summary_air_gapped">Ok: Air Gapped</string>
     <string name="UnifiedPushSettingsFragment__status_summary_mollysocket_url_missing">MollySocket url missing</string>
     <string name="UnifiedPushSettingsFragment__status_summary_pending">Pending</string>
     <string name="UnifiedPushSettingsFragment__status_summary_mollysocket_server_not_found">MollySocket server not found</string>
@@ -138,10 +138,10 @@
     <string name="UnifiedPushSettingsFragment__status_summary_forbidden_endpoint">The endpoint is forbidden by the server</string>
     <string name="UnifiedPushSettingsFragment__status_summary_no_distributor">No UnifiedPush distributor installed</string>
     <string name="UnifiedPushSettingsFragment__status_summary_unknown_error">Unknown error</string>
-    <string name="UnifiedPushSettingsFragment__air_gaped_summary">Enable if your MollySocket server can\'t be reach on the Internet. You will have to register the connection manually</string>
+    <string name="UnifiedPushSettingsFragment__air_gapped_summary">Enable if your MollySocket server can\'t be reach on the Internet. You will have to register the connection manually</string>
     <string name="UnifiedPushNotificationBuilder__title">UnifiedPush</string>
     <string name="UnifiedPushNotificationBuilder__mollysocket_registration_changed">Your registration on MollySocket isn\'t valid anymore. Try to remove the linked device and register again.</string>
-    <string name="UnifiedPushNotificationBuilder__endpoint_changed_airgaped">Your UnifiedPush endpoint has changed. You must update your connection on MollySocket.</string>
+    <string name="UnifiedPushNotificationBuilder__endpoint_changed_airgapped">Your UnifiedPush endpoint has changed. You must update your connection on MollySocket.</string>
     <string name="UnifiedPushNotificationBuilder__endpoint_changed_error">An error occurred while changing your UnifiedPush endpoint. Try to register again to MollySocket.</string>
     <string name="UnifiedPushNotificationBuilder__registration_failed">Your UnifiedPush distributor refused the registration. You may not have any connection or a requirement is missing for your distributor.</string>
     <string name="NotificationMethod__label_unifiedpush">UnifiedPush</string>

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/components/settings/app/notifications/UnifiedPushSettingsFragment.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/components/settings/app/notifications/UnifiedPushSettingsFragment.kt
@@ -60,15 +60,15 @@ class UnifiedPushSettingsFragment : DSLSettingsFragment(R.string.NotificationsSe
       dividerPref()
 
       switchPref(
-        title = DSLSettingsText.from(getString(R.string.UnifiedPushSettingsFragment__air_gaped)),
-        summary = DSLSettingsText.from(getString(R.string.UnifiedPushSettingsFragment__air_gaped_summary)),
-        isChecked = state.airGaped,
+        title = DSLSettingsText.from(getString(R.string.UnifiedPushSettingsFragment__air_gapped)),
+        summary = DSLSettingsText.from(getString(R.string.UnifiedPushSettingsFragment__air_gapped_summary)),
+        isChecked = state.airGapped,
         onClick = {
-          viewModel.setUnifiedPushAirGaped(!state.airGaped)
+          viewModel.setUnifiedPushAirGapped(!state.airGapped)
         }
       )
 
-      if (state.airGaped) {
+      if (state.airGapped) {
 
         clickPref(
           title = DSLSettingsText.from(getString(R.string.UnifiedPushSettingsFragment__server_parameters)),
@@ -147,7 +147,7 @@ class UnifiedPushSettingsFragment : DSLSettingsFragment(R.string.NotificationsSe
     return when (state.status) {
       UnifiedPushStatus.DISABLED -> getString(R.string.UnifiedPushSettingsFragment__status_summary_disabled)
       UnifiedPushStatus.LINK_DEVICE_ERROR -> getString(R.string.UnifiedPushSettingsFragment__status_summary_linked_device_error)
-      UnifiedPushStatus.AIR_GAPED -> getString(R.string.UnifiedPushSettingsFragment__status_summary_air_gaped)
+      UnifiedPushStatus.AIR_GAPPED -> getString(R.string.UnifiedPushSettingsFragment__status_summary_air_gapped)
       UnifiedPushStatus.SERVER_NOT_FOUND_AT_URL -> getString(R.string.UnifiedPushSettingsFragment__status_summary_mollysocket_server_not_found)
       UnifiedPushStatus.MISSING_ENDPOINT -> getString(R.string.UnifiedPushSettingsFragment__status_summary_missing_endpoint)
       UnifiedPushStatus.FORBIDDEN_UUID -> getString(R.string.UnifiedPushSettingsFragment__status_summary_forbidden_uuid)

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/components/settings/app/notifications/UnifiedPushSettingsState.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/components/settings/app/notifications/UnifiedPushSettingsState.kt
@@ -9,7 +9,7 @@ data class Distributor(
 )
 
 data class UnifiedPushSettingsState(
-  val airGaped: Boolean,
+  val airGapped: Boolean,
   val device: MollyDevice?,
   val distributors: List<Distributor>,
   val selected: Int,

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/components/settings/app/notifications/UnifiedPushSettingsViewModel.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/components/settings/app/notifications/UnifiedPushSettingsViewModel.kt
@@ -77,7 +77,7 @@ class UnifiedPushSettingsViewModel(private val application: Application) : ViewM
     }
 
     return UnifiedPushSettingsState(
-      airGaped = SignalStore.unifiedpush().airGaped,
+      airGapped = SignalStore.unifiedpush().airGapped,
       device = SignalStore.unifiedpush().device,
       distributors = distributors,
       selected = selected,
@@ -88,8 +88,8 @@ class UnifiedPushSettingsViewModel(private val application: Application) : ViewM
     )
   }
 
-  fun setUnifiedPushAirGaped(airGaped: Boolean) {
-    SignalStore.unifiedpush().airGaped = airGaped
+  fun setUnifiedPushAirGapped(airGapped: Boolean) {
+    SignalStore.unifiedpush().airGapped = airGapped
     processNewStatus()
   }
 

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/jobs/UnifiedPushRefreshJob.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/jobs/UnifiedPushRefreshJob.kt
@@ -72,8 +72,8 @@ class UnifiedPushRefreshJob private constructor(parameters: Parameters) : BaseJo
         reInitializeNotificationServices()
       }
       // Considered as successful setup
-      UnifiedPushStatus.AIR_GAPED -> {
-        Log.i(TAG, "UnifiedPush available in AirGaped mode. No MollySocket to register to.")
+      UnifiedPushStatus.AIR_GAPPED -> {
+        Log.i(TAG, "UnifiedPush available in AirGapped mode. No MollySocket to register to.")
         reInitializeNotificationServices()
       }
       // We try to register to MollySocket server,

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/model/UnifiedPushStatus.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/model/UnifiedPushStatus.kt
@@ -2,7 +2,7 @@ package im.molly.unifiedpush.model
 
 enum class UnifiedPushStatus {
   DISABLED,
-  AIR_GAPED,
+  AIR_GAPPED,
   SERVER_NOT_FOUND_AT_URL,
   MISSING_ENDPOINT,
   FORBIDDEN_UUID,

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/util/UnifiedPushHelper.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/util/UnifiedPushHelper.kt
@@ -28,7 +28,7 @@ object UnifiedPushHelper {
   @JvmStatic
   fun isUnifiedPushAvailable(): Boolean {
     return SignalStore.account().isRegistered &&
-      SignalStore.unifiedpush().status in listOf(UnifiedPushStatus.OK, UnifiedPushStatus.AIR_GAPED)
+      SignalStore.unifiedpush().status in listOf(UnifiedPushStatus.OK, UnifiedPushStatus.AIR_GAPPED)
   }
 
   @JvmStatic

--- a/app/src/unifiedpush/java/im/molly/unifiedpush/util/UnifiedPushNotificationBuilder.kt
+++ b/app/src/unifiedpush/java/im/molly/unifiedpush/util/UnifiedPushNotificationBuilder.kt
@@ -29,9 +29,9 @@ class UnifiedPushNotificationBuilder(val context: Context) {
       .notify(NOTIFICATION_ID_UNIFIEDPUSH, getNotification(context.getString(R.string.UnifiedPushNotificationBuilder__mollysocket_registration_changed)))
   }
 
-  fun setNotificationEndpointChangedAirGaped() {
+  fun setNotificationEndpointChangedAirGapped() {
     (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
-      .notify(NOTIFICATION_ID_UNIFIEDPUSH, getNotification(context.getString(R.string.UnifiedPushNotificationBuilder__endpoint_changed_airgaped)))
+      .notify(NOTIFICATION_ID_UNIFIEDPUSH, getNotification(context.getString(R.string.UnifiedPushNotificationBuilder__endpoint_changed_airgapped)))
   }
 
   fun setNotificationEndpointChangedError() {

--- a/app/src/unifiedpush/java/org/thoughtcrime/securesms/keyvalue/UnifiedPushValues.kt
+++ b/app/src/unifiedpush/java/org/thoughtcrime/securesms/keyvalue/UnifiedPushValues.kt
@@ -17,7 +17,7 @@ internal class UnifiedPushValues(store: KeyValueStore) : SignalStoreValues(store
     private const val UNIFIEDPUSH_ENDPOINT = "unifiedpush.endpoint"
     private const val UNIFIEDPUSH_ENABLED = "unifiedpush.enabled"
     private const val UNIFIEDPUSH_PENDING = "unifiedpush.pending"
-    private const val UNIFIEDPUSH_AIR_GAPED = "unifiedpush.air_gaped"
+    private const val UNIFIEDPUSH_AIR_GAPPED = "unifiedpush.air_gapped"
   }
 
   override fun onFirstEverAppLaunch() = Unit
@@ -48,7 +48,7 @@ internal class UnifiedPushValues(store: KeyValueStore) : SignalStoreValues(store
 
   var pending: Boolean by booleanValue(UNIFIEDPUSH_PENDING, false)
 
-  var airGaped: Boolean by booleanValue(UNIFIEDPUSH_AIR_GAPED, false)
+  var airGapped: Boolean by booleanValue(UNIFIEDPUSH_AIR_GAPPED, false)
 
   var mollySocketUrl: String? by stringValue(MOLLYSOCKET_URL, null)
 
@@ -66,7 +66,7 @@ internal class UnifiedPushValues(store: KeyValueStore) : SignalStoreValues(store
       SignalStore.unifiedpush().pending -> UnifiedPushStatus.PENDING
       SignalStore.unifiedpush().device == null -> UnifiedPushStatus.LINK_DEVICE_ERROR
       SignalStore.unifiedpush().endpoint == null -> UnifiedPushStatus.MISSING_ENDPOINT
-      SignalStore.unifiedpush().airGaped -> UnifiedPushStatus.AIR_GAPED
+      SignalStore.unifiedpush().airGapped -> UnifiedPushStatus.AIR_GAPPED
       SignalStore.unifiedpush().mollySocketUrl.isNullOrBlank() ||
         !SignalStore.unifiedpush().mollySocketFound -> UnifiedPushStatus.SERVER_NOT_FOUND_AT_URL
       SignalStore.unifiedpush().mollySocketInternalError -> UnifiedPushStatus.INTERNAL_ERROR


### PR DESCRIPTION
Fix Air Gaped -> Air Gapped

In case the code base changes break something or are not wanted for other reasons it should be enough to merge the first commit to fix the user-facing labels.